### PR TITLE
Gpt/fix hash filename sanitization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/convoviz/utils.py
+++ b/convoviz/utils.py
@@ -71,7 +71,7 @@ def sanitize(text: str, *, preserve_unicode: bool = False) -> str:
 
     # 3. Replace invalid characters with spaces
     # (including @ which messes with some PDF tools)
-    pattern = re.compile(r'[@<>:"/\\|?*\n\r\t\f\v]+')
+    pattern = re.compile(r'[@<>:"/\\|?*\n\r\t\f\v#]+')
     result = pattern.sub(" ", ascii_text)
 
     # 4. Prevent path traversal by replacing dots with spaces

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -28,6 +28,8 @@ class TestSanitize:
         assert sanitize("file:name") == "file name"
         assert sanitize("path/to\\file") == "path to file"
         assert sanitize("test?query*") == "test query"
+        assert sanitize("Hello#World") == "Hello World"
+        assert sanitize("### Title ###") == "Title"
 
     def test_sanitize_with_newlines(self) -> None:
         """Test sanitizing strings with newlines."""
@@ -79,7 +81,6 @@ class TestSanitize:
         input_str = " @[Mörön] - 100% Crème brûlée! 😀 "
         # 1. Transliterate: " @[Moron] - 100% Creme brulee!  "
         # 2. Invalid chars (@, [, ], %, !): "  Moron - 100 Creme brulee  "
-        # 3. Collapse/Strip: "Moron - 100 Creme brulee"
         # Wait, [ ] and % and ! are NOT in the invalid set pattern [@<>:\"/\\|?*\n\r\t\f\v]+
         # So they remain if they are ASCII.
         # My current pattern is [@<>:\"/\\|?*\n\r\t\f\v]+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -98,7 +98,9 @@ class TestSanitize:
             "Синонимы для каталога"
         )
 
-    def test_sanitize_preserves_unicode_but_removes_invalid_filename_chars(self) -> None:
+    def test_sanitize_preserves_unicode_but_removes_invalid_filename_chars(
+        self,
+    ) -> None:
         """Test Unicode preservation does not bypass filename sanitization."""
         assert sanitize("Синонимы: для/каталога?", preserve_unicode=True) == (
             "Синонимы для каталога"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -80,9 +80,9 @@ class TestSanitize:
         # 1. Transliterate: " @[Moron] - 100% Creme brulee!  "
         # 2. Invalid chars (@, [, ], %, !): "  Moron - 100 Creme brulee  "
         # 3. Collapse/Strip: "Moron - 100 Creme brulee"
-        # Wait, [ ] and % and ! are NOT in the invalid set pattern [@<>:"/\\|?*\n\r\t\f\v]+
+        # Wait, [ ] and % and ! are NOT in the invalid set pattern [@<>:\"/\\|?*\n\r\t\f\v]+
         # So they remain if they are ASCII.
-        # My current pattern is [@<>:"/\\|?*\n\r\t\f\v]+
+        # My current pattern is [@<>:\"/\\|?*\n\r\t\f\v]+
         # Let's see what happens.
         result = sanitize(input_str)
         assert "Moron" in result
@@ -90,6 +90,23 @@ class TestSanitize:
         assert "😀" not in result
         # Check that it is purely ASCII
         result.encode("ascii")
+
+    def test_sanitize_preserves_cyrillic_when_requested(self) -> None:
+        """Test that Unicode letters are preserved when requested."""
+        assert sanitize("Синонимы для каталога", preserve_unicode=True) == (
+            "Синонимы для каталога"
+        )
+
+    def test_sanitize_preserves_unicode_but_removes_invalid_filename_chars(self) -> None:
+        """Test Unicode preservation does not bypass filename sanitization."""
+        assert sanitize("Синонимы: для/каталога?", preserve_unicode=True) == (
+            "Синонимы для каталога"
+        )
+
+    def test_sanitize_normalizes_preserved_unicode(self) -> None:
+        """Test that preserved Unicode is normalized to NFC."""
+        decomposed = "и\u0306"
+        assert sanitize(decomposed, preserve_unicode=True) == "й"
 
 
 class TestValidateHeader:


### PR DESCRIPTION
 ## Problem

Obsidian uses the `#` character as a special separator in links to headings.

For example, a Markdown file named:

```text
Рассинхрон доступа C#.md
```

can be interpreted by Obsidian as a link to a file named:

```text
Рассинхрон доступа C
```

with `#...` treated as a heading fragment.

This causes a particularly problematic behavior in Obsidian Bases: when a table contains a file whose name includes `#`, clicking the file link causes Obsidian to create a new, empty file with the `#` portion removed.

## Change

Add `#` to the set of characters sanitized when generating filenames.

The character is replaced with a space, consistent with the existing filename sanitization behavior:

```text
Рассинхрон доступа C#.md
        ↓
Рассинхрон доступа C.md
```

The `#` character is not removed from the original conversation data. In particular, when the filename is changed, convoviz can preserve the original title as an alias according to its existing behavior.

## Why replace `#` with a space?

A visually similar Unicode character could be used instead, for example FULLWIDTH NUMBER SIGN (`＃`):

```text
C# → C＃
```

This would preserve the visual meaning better than replacing it with a space. However, the resulting filename would contain a different Unicode character. A user searching for files containing the normal `#` character may not find files containing `＃`, which can be confusing.

Replacing `#` with a space therefore provides a simpler and more predictable filename for Obsidian users, at the cost of losing that character from the filename itself.

This PR intentionally does not change convoviz's existing title/alias contract or introduce a different filename representation. The maintainer can decide whether a different replacement character or another approach would be preferable in the future.

## Tests

Regression tests cover:

- preservation of Unicode text when requested;
- removal/replacement of invalid filename characters;
- NFC normalization of preserved Unicode text;
- `#` replacement during filename sanitization.

All CI checks pass, including tests on Python 3.12, 3.13, and 3.14, type checking, linting, and installation checks.